### PR TITLE
Adjust the counting method of words to adapt to Chinese, Japanese, Korean, etc.

### DIFF
--- a/FuzRoDohInternals.cpp
+++ b/FuzRoDohInternals.cpp
@@ -17,6 +17,11 @@ SME::INI::INISetting	kWordsPerSecondSilence("WordsPerSecondSilence",
 											   "Number of words a second of silent voice can \"hold\"",
 											   (SInt32)2);
 
+SME::INI::INISetting	kWideCharacterPerWord("WideCharacterPerWord",
+												"General",
+												"In Chinese, Japanese, Korean and other wide character languages, how many wide characters are regarded as a word",
+												(SInt32)4);
+
 SME::INI::INISetting	kSkipEmptyResponses("SkipEmptyResponses",
 											"General",
 											"Don't play back silent dialog for empty dialog responses",
@@ -58,6 +63,7 @@ void FuzRoDohINIManager::Initialize(const char* INIPath, void* Paramenter)
 	INIStream.clear();
 
 	RegisterSetting(&kWordsPerSecondSilence);
+	RegisterSetting(&kWideCharacterPerWord);
 	RegisterSetting(&kSkipEmptyResponses);
 
 	if (CreateINI)

--- a/FuzRoDohInternals.cpp
+++ b/FuzRoDohInternals.cpp
@@ -20,7 +20,7 @@ SME::INI::INISetting	kWordsPerSecondSilence("WordsPerSecondSilence",
 SME::INI::INISetting	kWideCharacterPerWord("WideCharacterPerWord",
 												"General",
 												"In Chinese, Japanese, Korean and other wide character languages, how many wide characters are regarded as a word",
-												(SInt32)4);
+												(SInt32)3);
 
 SME::INI::INISetting	kSkipEmptyResponses("SkipEmptyResponses",
 											"General",

--- a/FuzRoDohInternals.h
+++ b/FuzRoDohInternals.h
@@ -28,6 +28,7 @@ namespace interfaces
 
 
 extern SME::INI::INISetting				kWordsPerSecondSilence;
+extern SME::INI::INISetting				kWideCharacterPerWord;
 extern SME::INI::INISetting				kSkipEmptyResponses;
 
 #define MAKE_RVA(addr)		addr - 0x140000000i64

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -95,20 +95,14 @@ void SneakAtackVoicePath(CachedResponseData* Data, char* VoicePathBuffer)
 				if (ch & 0x80 && ch & 0x40 && ch & 0x20)
 				{
 					if (ch & 0x10)
-					{
 						CharOver = 3; // a 4 wide-character, 3 bytes left
-					}
 					else
-					{
 						CharOver = 2; // a 3 wide-character, 2 bytes left
-					}
 					WideCharCount ++;
 					// What about 2 wide-character? These "2 wide-character languages" basically use spaces to separate words by my google
 				}
 				else
-				{
 					WordCount += (ch == ' ');
-				}
 			}
 			WordCount += (WideCharCount / kCharacterPerWord);
 

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -73,6 +73,7 @@ void SneakAtackVoicePath(CachedResponseData* Data, char* VoicePathBuffer)
 #endif
 	{
 		static const int kWordsPerSecond = kWordsPerSecondSilence.GetData().i;
+		static const int kCharacterPerWord = kWideCharacterPerWord.GetData().i;
 		static const int kMaxSeconds = 10;
 
 		int SecondsOfSilence = 2;
@@ -81,11 +82,35 @@ void SneakAtackVoicePath(CachedResponseData* Data, char* VoicePathBuffer)
 
 		if (ResponseText.length() > 4 && strncmp(ResponseText.c_str(), "<ID=", 4))
 		{
-			SME::StringHelpers::Tokenizer TextParser(ResponseText.c_str(), " ");
 			int WordCount = 0;
-
-			while (TextParser.NextToken(ResponseText) != -1)
-				WordCount++;
+			int WideCharCount = 0;
+			int CharOver = 0;
+			for (char ch : ResponseText) // check each character
+			{
+				if (CharOver > 0) // this char is part of a wide-character, pass it
+				{
+					CharOver --;
+					continue;
+				}
+				if (ch & 0x80 && ch & 0x40 && ch & 0x20)
+				{
+					if (ch & 0x10)
+					{
+						CharOver = 3; // a 4 wide-character, 3 bytes left
+					}
+					else
+					{
+						CharOver = 2; // a 3 wide-character, 2 bytes left
+					}
+					WideCharCount ++;
+					// What about 2 wide-character? These "2 wide-character languages" basically use spaces to separate words by my google
+				}
+				else
+				{
+					WordCount += (ch == ' ');
+				}
+			}
+			WordCount += (WideCharCount / kCharacterPerWord);
 
 			SecondsOfSilence = WordCount / ((kWordsPerSecond > 0) ? kWordsPerSecond : 2) + 1;
 


### PR DESCRIPTION
Adjust the counting method of words to accommodate languages without spaces between words, such as Chinese, Japanese, and Korean.

Chinese tested, Japanese and Korean theory available, not tested.

Does not affect the normal use of English.


Implement:

The first 128 code points (ASCII) need one byte. The next 1,920 code points need two bytes to encode, which covers the remainder of almost all Latin-script alphabets, and also IPA extensions, Greek, Cyrillic, Coptic, Armenian, Hebrew, Arabic, Syriac, Thaana and N'Ko alphabets, as well as Combining Diacritical Marks. Three bytes are needed for the rest of the Basic Multilingual Plane, which contains virtually all code points in common use,[16] including most Chinese, Japanese and Korean characters. Four bytes are needed for code points in the other planes of Unicode, which include less common CJK characters, various historic scripts, mathematical symbols, and emoji (pictographic symbols). ---wikipedia

Does not affect one byte code and two byte code, For counting 3 byte code and 4 byte code, configure word segmentation according to `WideCharacterPerWord` in the ini file.